### PR TITLE
add `test` to jest globals

### DIFF
--- a/src/common/constants/builtIns.js
+++ b/src/common/constants/builtIns.js
@@ -75,6 +75,7 @@ module.exports = new Set([
   'describe',
   'expect',
   'it',
+  'test',
   'jest',
   'waitsForPromise',
   'jasmine',


### PR DESCRIPTION
not sure if it's the right place to do this. I alway get `test` requires added to my files when i use `cmd+shift+i` in nuclide
```js
const test = require('test');

test('something', () => expect(true).toBe(true));
```

