### PR TITLE
Use Babylon instead of outdated babel-core parser

### DIFF
--- a/__tests__/requiresTransform-spec.js
+++ b/__tests__/requiresTransform-spec.js
@@ -12,7 +12,7 @@ import DefaultModuleMap from '../src/common/state/DefaultModuleMap';
 
 import jscodeshift from 'jscodeshift';
 import printRoot from '../src/common/utils/printRoot';
-import requiresTransform from '../src/common/requires/transform';
+import transform from '../src/common/transform';
 import fs from 'fs';
 import path from 'path';
 
@@ -88,11 +88,7 @@ describe('requiresTransform', () => {
       const expectedPath = path.join(__dirname, 'fixtures/requires/' + name + '.expected');
 
       const test = await readFileP(testPath);
-
-      const root = jscodeshift(test);
-      requiresTransform(root, SOURCE_OPTIONS);
-      const actual = printRoot(root);
-
+      const actual = transform(test, SOURCE_OPTIONS);
       const expected = await readFileP(expectedPath);
       expect(actual).toBe(expected);
     });

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "babel-core": "5.8.38",
     "immutable": "3.7.6",
-    "jscodeshift": "0.3.20"
+    "jscodeshift": "^0.3.30"
   },
   "devDependencies": {
     "ast-types-flow": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "babel-core": "5.8.38",
     "immutable": "3.7.6",
-    "jscodeshift": "^0.3.30"
+    "jscodeshift": "0.3.30"
   },
   "devDependencies": {
     "ast-types-flow": "0.0.7",

--- a/src/common/state/ModuleMap.js
+++ b/src/common/state/ModuleMap.js
@@ -174,14 +174,14 @@ class ModuleMap {
 
     if (destructure && options.typeImport) {
       // import type {foo} from 'foo';
-      tmp = statement`import type {_} from '_'`;
+      tmp = statement`import type {_} from '_';\n`;
       tmp.specifiers[0].imported = idNode;
       tmp.specifiers[0].local = idNode;
       tmp.source = literalNode;
       return tmp;
     } else if (!destructure && options.typeImport) {
       // import type foo from 'foo';
-      tmp = statement`import type _ from '_'`;
+      tmp = statement`import type _ from '_';\n`;
       tmp.specifiers[0].id = idNode;
       tmp.specifiers[0].local = idNode;
       tmp.source = literalNode;

--- a/src/common/transform.js
+++ b/src/common/transform.js
@@ -11,6 +11,7 @@
 import type {SourceOptions} from './options/SourceOptions';
 
 import jscs from 'jscodeshift';
+import getParser from 'jscodeshift/dist/getParser';
 
 import Options from './options/Options';
 import nuclideTransform from './nuclide/transform';
@@ -21,7 +22,7 @@ function transform(source: string, options: SourceOptions): string {
   Options.validateSourceOptions(options);
 
   // Parse the source code once, then reuse the root node
-  const root = jscs(source);
+  const root = jscs(source, {parser: getParser('babylon')});
 
   // Add use-strict
   // TODO: implement this, make it configurable

--- a/src/common/utils/getDeclaredIdentifiers.js
+++ b/src/common/utils/getDeclaredIdentifiers.js
@@ -37,6 +37,18 @@ const CONFIG: Array<ConfigEntry> = [
     getNodes: path => [path.node.rest].concat(path.node.params),
   },
 
+  // class {foo(...rest) {}}, class method
+  {
+    searchTerms: [jscs.ClassMethod],
+    getNodes: path => path.node.params,
+  },
+
+  // x = {foo(...rest) {}}, object method
+  {
+    searchTerms: [jscs.ObjectMethod],
+    getNodes: path => path.node.params,
+  },
+
   // var foo;
   {
     searchTerms: [jscs.VariableDeclaration],

--- a/src/common/utils/getDeclaredTypes.js
+++ b/src/common/utils/getDeclaredTypes.js
@@ -72,7 +72,7 @@ function getDeclaredTypes(
       .forEach(path => {
         const nodes = config.getNodes(path);
         nodes.forEach(node => {
-          if (jscs.Identifier.check(node)) {
+          if (jscs.Identifier.check(node) || jscs.TypeParameter.check(node)) {
             ids.add(node.name);
           }
         });

--- a/src/common/utils/getNamesFromID.js
+++ b/src/common/utils/getNamesFromID.js
@@ -19,7 +19,8 @@ function getNamesFromID(node: Node): Set<string> {
   } else if (
     jscs.RestElement.check(node) ||
     jscs.SpreadElement.check(node) ||
-    jscs.SpreadProperty.check(node)
+    jscs.SpreadProperty.check(node) ||
+    jscs.RestProperty.check(node)
   ) {
     for (const id of getNamesFromID(node.argument)) {
       ids.add(id);

--- a/src/common/utils/printRoot.js
+++ b/src/common/utils/printRoot.js
@@ -39,6 +39,9 @@ function printRoot(root: Collection): string {
   // Remove new lines at the start.
   output = output.replace(/^\n{1,}/, '');
 
+  // Remove spurious semicolon after 'use strict'
+  output = output.replace("'use strict';;", "'use strict';");
+
   // Make sure there is a new line at the end.
   if (!/^[\w\W]*\n$/.test(output)) {
     output += '\n';


### PR DESCRIPTION
Had to bump jscodeshift for this. There is one test failing atm, I will fix recast to fix it (https://github.com/benjamn/recast/issues/327). Name-less function type params also don't work until https://github.com/babel/babylon/pull/565 gets merged. Otherwise it looks ok to me. On top of this I want to fix the order of type imports to align with our in-house eslint order (which is sorting by module name).