### PR TITLE
Ignore Flow utility types

### DIFF
--- a/__tests__/fixtures/requires/ignore-flow-utility-types.expected
+++ b/__tests__/fixtures/requires/ignore-flow-utility-types.expected
@@ -1,0 +1,3 @@
+import type Suit from 'Suit';
+
+const clubs: $Keys<Class<Suit>> = 'Clubs';

--- a/__tests__/fixtures/requires/ignore-flow-utility-types.test
+++ b/__tests__/fixtures/requires/ignore-flow-utility-types.test
@@ -1,0 +1,1 @@
+const clubs: $Keys<Class<Suit>> = 'Clubs';

--- a/__tests__/requiresTransform-spec.js
+++ b/__tests__/requiresTransform-spec.js
@@ -50,6 +50,7 @@ const TESTS = [
   'ignore-comments-with-no-requires',
   'ignore-declared-jsx',
   'ignore-function-params',
+  'ignore-flow-utility-types',
   'ignore-nested-object-patterns',
   'ignore-react-when-using-jsx',
   'ignore-requires-in-blocks',

--- a/src/common/constants/builtInTypes.js
+++ b/src/common/constants/builtInTypes.js
@@ -15,6 +15,31 @@
  * should only be for declared types that are not actual modules.
  */
 module.exports = new Set([
+  // Flow built-in utility types
+  '$Abstract',
+  '$All',
+  '$Diff',
+  '$Either',
+  '$Enum',
+  '$Exact',
+  '$Exports',
+  '$Flow',
+  '$Keys',
+  '$NonMaybeType',
+  '$ObjMap',
+  '$ObjMapi',
+  '$Pred',
+  '$PropertyType',
+  '$ReadOnlyArray',
+  '$Refine',
+  '$Shape',
+  '$Subtype',
+  '$Supertype',
+  '$Tainted',
+  '$TupleMap',
+  '$Type',
+  'Class',
+  // Other FB/browser builtins
   '$jsx',
   'AdAccountID',
   'FBID',


### PR DESCRIPTION
I was thinking for a minute to ignore all `$DollarTypes`, but they are valid syntax in Flow 😿 , plus `Class` doesn't even use the `$` 😿 , plus they shouldn't be adding many more (and new ones probably won't be that widely used anyway). So I guess this is good enough.