### PR TITLE
Speed up transform by unrolling lookups

### DIFF
--- a/__tests__/requiresTransform-spec.js
+++ b/__tests__/requiresTransform-spec.js
@@ -10,8 +10,6 @@
 
 import DefaultModuleMap from '../src/common/state/DefaultModuleMap';
 
-import jscodeshift from 'jscodeshift';
-import printRoot from '../src/common/utils/printRoot';
 import transform from '../src/common/transform';
 import fs from 'fs';
 import path from 'path';

--- a/src/common/utils/FirstNode.js
+++ b/src/common/utils/FirstNode.js
@@ -26,35 +26,35 @@ const FirstNode = {
    */
   get(root: Collection): ?NodePath {
     let first;
-    root
-      .find(jscs.Node)
-      .filter(path => isGlobal(path))
-      .forEach(path => {
-        if (!first && FirstNode.isValidFirstNode(path)) {
-          first = path;
+    jscs.types.visit(root.nodes()[0], {
+      visitNode: function(path) {
+        if (isGlobal(path) && isValidFirstNode(path)) {
+          if (!first) {
+            first = path;
+          }
+          return false; // stop iterating the AST
         }
-      });
+        this.traverse(path);
+      }
+    });
     return first;
   },
-
-  /**
-   * Filter to see if a node is a valid first node.
-   */
-  isValidFirstNode(path: NodePath): boolean {
-    // A new line literal is okay.
-    if (match(path, {expression: {value: NewLine.literal}})) {
-      return true;
-    }
-    // Any other literal is not.
-    if (match(path, {expression: {type: 'Literal'}})) {
-      return false;
-    }
-    const firstObject = getRootIdentifierInExpression(path.node);
-    if (firstObject && match(firstObject, {name: 'jest'})) {
-      return false;
-    }
-    return true;
-  },
 };
+
+function isValidFirstNode(path: NodePath): boolean {
+  // A new line literal is okay.
+  if (match(path, {expression: {value: NewLine.literal}})) {
+    return true;
+  }
+  // Any other literal is not.
+  if (match(path, {expression: {type: 'Literal'}})) {
+    return false;
+  }
+  const firstObject = getRootIdentifierInExpression(path.node);
+  if (firstObject && match(firstObject, {name: 'jest'})) {
+    return false;
+  }
+  return true;
+}
 
 module.exports = FirstNode;

--- a/src/common/utils/getDeclaredIdentifiers.js
+++ b/src/common/utils/getDeclaredIdentifiers.js
@@ -15,7 +15,7 @@ import getNamesFromID from './getNamesFromID';
 import jscs from 'jscodeshift';
 
 type ConfigEntry = {
-  searchTerms: [any, ?Object],
+  nodeType: string,
   getNodes: (path: NodePath) => Array<Node>,
 };
 
@@ -27,55 +27,55 @@ type ConfigEntry = {
 const CONFIG: Array<ConfigEntry> = [
   // function foo(...rest) {}
   {
-    searchTerms: [jscs.FunctionDeclaration],
+    nodeType: jscs.FunctionDeclaration,
     getNodes: path => [path.node.id, path.node.rest].concat(path.node.params),
   },
 
   // foo(...rest) {}, in a class body for example
   {
-    searchTerms: [jscs.FunctionExpression],
+    nodeType: jscs.FunctionExpression,
     getNodes: path => [path.node.rest].concat(path.node.params),
   },
 
   // class {foo(...rest) {}}, class method
   {
-    searchTerms: [jscs.ClassMethod],
+    nodeType: jscs.ClassMethod,
     getNodes: path => path.node.params,
   },
 
   // x = {foo(...rest) {}}, object method
   {
-    searchTerms: [jscs.ObjectMethod],
+    nodeType: jscs.ObjectMethod,
     getNodes: path => path.node.params,
   },
 
   // var foo;
   {
-    searchTerms: [jscs.VariableDeclaration],
+    nodeType: jscs.VariableDeclaration,
     getNodes: path => path.node.declarations.map(declaration => declaration.id),
   },
 
   // class foo {}
   {
-    searchTerms: [jscs.ClassDeclaration],
+    nodeType: jscs.ClassDeclaration,
     getNodes: path => [path.node.id],
   },
 
   // (foo, ...rest) => {}
   {
-    searchTerms: [jscs.ArrowFunctionExpression],
+    nodeType: jscs.ArrowFunctionExpression,
     getNodes: path => [path.node.rest].concat(path.node.params),
   },
 
   // try {} catch (foo) {}
   {
-    searchTerms: [jscs.CatchClause],
+    nodeType: jscs.CatchClause,
     getNodes: path => [path.node.param],
   },
 
   // function foo(a = b) {}
   {
-    searchTerms: [jscs.AssignmentPattern],
+    nodeType: jscs.AssignmentPattern,
     getNodes: path => [path.node.left],
   },
 ];
@@ -93,7 +93,7 @@ function getDeclaredIdentifiers(
   const ids = new Set(moduleMap.getBuiltIns());
   const visitor = {};
   CONFIG.forEach(config => {
-    visitor[`visit${config.searchTerms[0]}`] = function(path) {
+    visitor[`visit${config.nodeType}`] = function(path) {
       if (!filters || filters.every(filter => filter(path))) {
         const nodes = config.getNodes(path);
         nodes.forEach(node => {

--- a/src/common/utils/getDeclaredIdentifiers.js
+++ b/src/common/utils/getDeclaredIdentifiers.js
@@ -91,11 +91,10 @@ function getDeclaredIdentifiers(
   // Start with the globals since they are always "declared" and safe to use.
   const {moduleMap} = options;
   const ids = new Set(moduleMap.getBuiltIns());
+  const visitor = {};
   CONFIG.forEach(config => {
-    root
-      .find(config.searchTerms[0], config.searchTerms[1])
-      .filter(path => (filters ? filters.every(filter => filter(path)) : true))
-      .forEach(path => {
+    visitor[`visit${config.searchTerms[0]}`] = function(path) {
+      if (!filters || filters.every(filter => filter(path))) {
         const nodes = config.getNodes(path);
         nodes.forEach(node => {
           const names = getNamesFromID(node);
@@ -103,8 +102,11 @@ function getDeclaredIdentifiers(
             ids.add(name);
           }
         });
-      });
+      }
+      this.traverse(path);
+    }
   });
+  jscs.types.visit(root.nodes()[0], visitor);
   return ids;
 }
 

--- a/src/common/utils/getNonDeclarationIdentifiers.js
+++ b/src/common/utils/getNonDeclarationIdentifiers.js
@@ -207,19 +207,22 @@ const CONFIG: Array<ConfigEntry> = [
  */
 function getNonDeclarationIdentifiers(root: Collection): Set<string> {
   const ids = new Set();
+  const visitor = {};
+
   CONFIG.forEach(config => {
-    root
-      .find(config.searchTerms[0], config.searchTerms[1])
-      .forEach(path => {
-        const nodes = config.getNodes(path);
-        nodes.forEach(node => {
-          const names = getNamesFromID(node);
-          for (const name of names) {
-            ids.add(name);
-          }
-        });
+    visitor[`visit${config.searchTerms[0]}`] = function(path) {
+      const nodes = config.getNodes(path);
+      nodes.forEach(node => {
+        const names = getNamesFromID(node);
+        for (const name of names) {
+          ids.add(name);
+        }
       });
+      this.traverse(path);
+    }
   });
+
+  jscs.types.visit(root.nodes()[0], visitor);
   return ids;
 }
 

--- a/src/common/utils/getNonDeclarationIdentifiers.js
+++ b/src/common/utils/getNonDeclarationIdentifiers.js
@@ -14,7 +14,7 @@ import getNamesFromID from './getNamesFromID';
 import jscs from 'jscodeshift';
 
 type ConfigEntry = {
-  searchTerms: [any, ?Object],
+  nodeType: string,
   getNodes: (path: NodePath) => Array<Node>,
 };
 
@@ -27,92 +27,92 @@ const REACT_NODE = jscs.identifier('React');
 const CONFIG: Array<ConfigEntry> = [
   // foo;
   {
-    searchTerms: [jscs.ExpressionStatement],
+    nodeType: jscs.ExpressionStatement,
     getNodes: path => [path.node.expression],
   },
 
   // foo(bar);
   {
-    searchTerms: [jscs.CallExpression],
+    nodeType: jscs.CallExpression,
     getNodes: path => [path.node.callee].concat(path.node.arguments),
   },
 
   // foo.declared;
   {
-    searchTerms: [jscs.MemberExpression],
+    nodeType: jscs.MemberExpression,
     getNodes: path => [path.node.object],
   },
 
   // foo = bar;
   {
-    searchTerms: [jscs.AssignmentExpression],
+    nodeType: jscs.AssignmentExpression,
     getNodes: path => [path.node.left, path.node.right],
   },
 
   // class declared extends foo {}
   {
-    searchTerms: [jscs.ClassDeclaration],
+    nodeType: jscs.ClassDeclaration,
     getNodes: path => [path.node.superClass],
   },
 
   // var declared = foo;
   {
-    searchTerms: [jscs.VariableDeclarator],
+    nodeType: jscs.VariableDeclarator,
     getNodes: path => [path.node.init],
   },
 
   // switch (declared) { case foo: break; }
   {
-    searchTerms: [jscs.SwitchCase],
+    nodeType: jscs.SwitchCase,
     getNodes: path => [path.node.test],
   },
 
   // {declared: foo}
   {
-    searchTerms: [jscs.ObjectExpression],
+    nodeType: jscs.ObjectExpression,
     // Generally props have a value, if it is a spread property it doesn't.
     getNodes: path => path.node.properties.map(prop => prop.value || prop),
   },
 
   // return foo;
   {
-    searchTerms: [jscs.ReturnStatement],
+    nodeType: jscs.ReturnStatement,
     getNodes: path => [path.node.argument],
   },
 
   // if (foo) {}
   {
-    searchTerms: [jscs.IfStatement],
+    nodeType: jscs.IfStatement,
     getNodes: path => [path.node.test],
   },
 
   // switch (foo) {}
   {
-    searchTerms: [jscs.SwitchStatement],
+    nodeType: jscs.SwitchStatement,
     getNodes: path => [path.node.discriminant],
   },
 
   // !foo;
   {
-    searchTerms: [jscs.UnaryExpression],
+    nodeType: jscs.UnaryExpression,
     getNodes: path => [path.node.argument],
   },
 
   // foo || bar;
   {
-    searchTerms: [jscs.BinaryExpression],
+    nodeType: jscs.BinaryExpression,
     getNodes: path => [path.node.left, path.node.right],
   },
 
   // foo < bar;
   {
-    searchTerms: [jscs.LogicalExpression],
+    nodeType: jscs.LogicalExpression,
     getNodes: path => [path.node.left, path.node.right],
   },
 
   // foo ? bar : baz;
   {
-    searchTerms: [jscs.ConditionalExpression],
+    nodeType: jscs.ConditionalExpression,
     getNodes: path => [
       path.node.test,
       path.node.alternate,
@@ -122,79 +122,79 @@ const CONFIG: Array<ConfigEntry> = [
 
   // new Foo()
   {
-    searchTerms: [jscs.NewExpression],
+    nodeType: jscs.NewExpression,
     getNodes: path => [path.node.callee].concat(path.node.arguments),
   },
 
   // foo++;
   {
-    searchTerms: [jscs.UpdateExpression],
+    nodeType: jscs.UpdateExpression,
     getNodes: path => [path.node.argument],
   },
 
   // <Element attribute={foo} />
   {
-    searchTerms: [jscs.JSXExpressionContainer],
+    nodeType: jscs.JSXExpressionContainer,
     getNodes: path => [path.node.expression],
   },
 
   // for (foo in bar) {}
   {
-    searchTerms: [jscs.ForInStatement],
+    nodeType: jscs.ForInStatement,
     getNodes: path => [path.node.left, path.node.right],
   },
 
   // for (foo of bar) {}
   {
-    searchTerms: [jscs.ForOfStatement],
+    nodeType: jscs.ForOfStatement,
     getNodes: path => [path.node.left, path.node.right],
   },
 
   // for (foo; bar; baz) {}
   {
-    searchTerms: [jscs.ForStatement],
+    nodeType: jscs.ForStatement,
     getNodes: path => [path.node.init, path.node.test, path.node.update],
   },
 
   // while (foo) {}
   {
-    searchTerms: [jscs.WhileStatement],
+    nodeType: jscs.WhileStatement,
     getNodes: path => [path.node.test],
   },
 
   // do {} while (foo)
   {
-    searchTerms: [jscs.DoWhileStatement],
+    nodeType: jscs.DoWhileStatement,
     getNodes: path => [path.node.test],
   },
 
   // [foo]
   {
-    searchTerms: [jscs.ArrayExpression],
+    nodeType: jscs.ArrayExpression,
     getNodes: path => path.node.elements,
   },
 
   // Special case. Any JSX elements will get transpiled to use React.
   {
-    searchTerms: [jscs.JSXOpeningElement],
+    nodeType: jscs.JSXOpeningElement,
     getNodes: path => [REACT_NODE],
   },
 
   // foo`something`
   {
-    searchTerms: [jscs.TaggedTemplateExpression],
+    nodeType: jscs.TaggedTemplateExpression,
     getNodes: path => [path.node.tag],
   },
 
   // `${bar}`
   {
-    searchTerms: [jscs.TemplateLiteral],
+    nodeType: jscs.TemplateLiteral,
     getNodes: path => path.node.expressions,
   },
 
   // function foo(a = b) {}
   {
-    searchTerms: [jscs.AssignmentPattern],
+    nodeType: jscs.AssignmentPattern,
     getNodes: path => [path.node.right],
   },
 ];
@@ -210,7 +210,7 @@ function getNonDeclarationIdentifiers(root: Collection): Set<string> {
   const visitor = {};
 
   CONFIG.forEach(config => {
-    visitor[`visit${config.searchTerms[0]}`] = function(path) {
+    visitor[`visit${config.nodeType}`] = function(path) {
       const nodes = config.getNodes(path);
       nodes.forEach(node => {
         const names = getNamesFromID(node);


### PR DESCRIPTION
The code before this change was traversing the whole AST for every single type of Node we were looking for. This was obviously costly. On this quite modest 80 line sample JS https://gist.github.com/xixixao/ef50c052b5bc6fa935b28f866a347a61 I got the `transform` time down from over 500ms to 160ms (for some reason Profile dumps are not saving for me in Atom, so you'll have to take my word for it):

before:
<img width="431" alt="screen shot 2017-06-12 at 01 31 36" src="https://user-images.githubusercontent.com/1473433/27015769-e9cf8bb0-4f0e-11e7-8f11-1dfdb196c283.png">
after:
<img width="417" alt="screen shot 2017-06-12 at 01 30 46" src="https://user-images.githubusercontent.com/1473433/27015768-e9c83784-4f0e-11e7-9c80-93fbc83b93f1.png">

There's clearly some code duplication here (there always was), let me know if it's worth cleaning up any further.