### PR TITLE
Final order

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,13 @@
 
 [![Build Status](https://travis-ci.org/facebooknuclide/nuclide-format-js.svg?branch=master)](https://travis-ci.org/facebooknuclide/nuclide-format-js)
 
-This feature is a collection of codemods that automatically clean up different aspects of code so
-that you do not have to worry about every little formatting detail. Right now all of the codemods
-live in `src/common` feature.
+Use this [Atom](https://atom.io/) plugin to automatically add `require` and `import` statements for values and types in your JavaScript.
 
-## usage
+## Usage
 
 The default keyboard shortcut for `nuclide-format-js:format` is `cmd-shift-i`.
 
-## codemods
-
-### requires
+## Details
 
 This collection of codemods automatically adds, removes, and formats your requires. It is primarily
 a heuristic that works by requiring identifiers that are being used that were not declared. It is
@@ -24,17 +20,48 @@ transforms:
 
 + Don't shadow require names anywhere in the file. The transform is very minimally aware of scope.
 + Don't alias requires (unless you specify the alias in the aliases setting).
-+ Destructure in a line separate from the require.
++ Destructure in a line separate from the require:
 
 ```js
 var React = require('react');
 var {PropTypes} = React;
 ```
 
+### Ordering Rules
+
+It is good to keep a consistent ordering of lists to avoid most merge conflicts. You do not need to
+remember the ordering specified here, it has been chosen to give good results and this plugin will
+automatically follow it.
+
+There are 4 groups separated by a blank line:
+
+1. type `import`s
+2. bare `require`s
+3. `require`s assigned to capitalized names (including in destructuring)
+4. `require`s assigned to lowercased names (including in destructuring)
+
+For example:
+
+```
+import type A from 'a';
+
+require('b');
+
+const C = require('c');
+
+const d = require('d');
+```
+
+Each group is then ordered by the module name (the string on the right hand side), ignoring
+its letter casing. The reason for using the module name as opposed to the type or value names
+on the left hand side is that with changing names in destructuring it is more likely that lines
+would shift, causing merge conflicts.
+
+### Scope
+
 There are also a few things that are not supported yet that would be nice to support:
 
 + Relative requires, e.g. `require('../lib/module');`
-+ Common destructures, e.g. `var {PropTypes} = require('react');`
 + Only add requires for known modules by maintaining a list of known modules, or by getting this
 information from Flow.
 + Allow per-directory configurations.
@@ -47,7 +74,7 @@ is getting in your way when using this plugin you can generally work around it b
 plugin's settings. It's possible to adjust things like built-ins, aliases, and even blacklist
 particular transforms there.
 
-## developing
+## Developing
 
 ```sh
 # Clone the repo
@@ -63,7 +90,7 @@ npm install
 npm run watch
 ```
 
-## releasing
+## Releasing
 
 * Make sure that `master` is up-to-date.
 

--- a/__tests__/fixtures/requires/sort-by-module-names.expected
+++ b/__tests__/fixtures/requires/sort-by-module-names.expected
@@ -1,0 +1,17 @@
+import type Z from 'A';
+import type X from 'b';
+import type Y from 'C';
+
+require('A');
+require('b');
+require('C');
+
+const W = require('A');
+const U = require('b');
+const V = require('C');
+
+const q = require('A');
+const r = require('b');
+const p = require('C');
+
+const m: [X, Y, Z] = p(q(r(U, V, W)));

--- a/__tests__/fixtures/requires/sort-by-module-names.test
+++ b/__tests__/fixtures/requires/sort-by-module-names.test
@@ -1,0 +1,14 @@
+const p = require('C');
+const q = require('A');
+const r = require('b');
+const U = require('b');
+const V = require('C');
+const W = require('A');
+import type X from 'b';
+import type Y from 'C';
+import type Z from 'A';
+require('A');
+require('b');
+require('C');
+
+const m: [X, Y, Z] = p(q(r(U, V, W)));

--- a/__tests__/fixtures/requires/sort-with-aliasing.expected
+++ b/__tests__/fixtures/requires/sort-with-aliasing.expected
@@ -1,0 +1,4 @@
+const Z = require('A').B.c.Y;
+const Y = require('AB');
+
+const x = Y + Z;

--- a/__tests__/fixtures/requires/sort-with-aliasing.test
+++ b/__tests__/fixtures/requires/sort-with-aliasing.test
@@ -1,0 +1,4 @@
+const Y = require('AB');
+const Z = require('A').B.c.Y;
+
+const x = Y + Z;

--- a/__tests__/requiresTransform-spec.js
+++ b/__tests__/requiresTransform-spec.js
@@ -65,6 +65,7 @@ const TESTS = [
   'remove-unused-types',
   'respect-declaration-kind',
   'sort-aliases',
+  'sort-by-module-names',
   'sort-import-specifiers',
   'sort-imports',
   'sort-requires',

--- a/src/common/requires/formatRequires.js
+++ b/src/common/requires/formatRequires.js
@@ -167,7 +167,14 @@ function getDeclarationName(node: Node): string {
 }
 
 function getDeclarationModuleName(node: Node): string {
-  return node.declarations[0].init.arguments[0].value;
+  let rhs = node.declarations[0].init;
+  const names = [];
+  while (jscs.MemberExpression.check(rhs)) {
+    names.unshift(rhs.property.name);
+    rhs = rhs.object;
+  }
+  names.unshift(rhs.arguments[0].value);
+  return names.join('_');
 }
 
 module.exports = formatRequires;

--- a/src/common/requires/formatRequires.js
+++ b/src/common/requires/formatRequires.js
@@ -63,8 +63,8 @@ const CONFIG: Array<ConfigEntry> = [
       path => isCapitalized(getDeclarationName(path.node)),
     ],
     comparator: (node1, node2) => compareStrings(
-      getDeclarationName(node1),
-      getDeclarationName(node2),
+      getDeclarationModuleName(node1),
+      getDeclarationModuleName(node2),
     ),
     mapper: node => reprintRequire(node),
   },
@@ -78,8 +78,8 @@ const CONFIG: Array<ConfigEntry> = [
       path => !isCapitalized(getDeclarationName(path.node)),
     ],
     comparator: (node1, node2) => compareStrings(
-      getDeclarationName(node1),
-      getDeclarationName(node2),
+      getDeclarationModuleName(node1),
+      getDeclarationModuleName(node2),
     ),
     mapper: node => reprintRequire(node),
   },
@@ -155,15 +155,19 @@ function getDeclarationName(node: Node): string {
   if (jscs.Identifier.check(declaration.id)) {
     return declaration.id.name;
   }
-  // Order by the first property name in the object pattern.
+  // Identify by the first property name in the object pattern.
   if (jscs.ObjectPattern.check(declaration.id)) {
     return declaration.id.properties[0].key.name;
   }
-  // Order by the first element name in the array pattern.
+  // Identify by the first element name in the array pattern.
   if (jscs.ArrayPattern.check(declaration.id)) {
     return declaration.id.elements[0].name;
   }
   return '';
+}
+
+function getDeclarationModuleName(node: Node): string {
+  return node.declarations[0].init.arguments[0].value;
 }
 
 module.exports = formatRequires;


### PR DESCRIPTION
The really nice thing about this rule (apart from it's surprising simplicity) is that it correctly orders our *** up immutable imports:

```es6
const Adam = require('Adam.react');
const Random = require('Random');
const Immutable = require('immutable');
const React = require('React');
```
removing the need for custom overrides (which we had in the order-requires ESLint rule).

I also fixed aliasing, and it sorts before longer names (deterministically):

```es6
const Col = require('React').Col;
const ReactCol = require('ReactCol');
```