### PR TITLE
Add error and success Atom notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,12 @@
       "type": "boolean",
       "default": true
     },
+    "moveCursorToSyntaxError": {
+      "title": "Move cursor to error",
+      "description": "Place the cursor at the location of the syntax error when the transform fails.",
+      "type": "boolean",
+      "default": true
+    },
     "nuclideFixHeader": {
       "title": "Nuclide: Fix Header",
       "description": "This is used to fix the header when developing on Nuclide source code. This should rarely affect anything outside of Nuclide source.",

--- a/package.json
+++ b/package.json
@@ -101,16 +101,17 @@
         "type": "string"
       }
     },
+    "confirmNoChangeSuccess": {
+      "title": "Confirm success",
+      "description": "Show a brief notification when the transform led to no changes.",
+      "type": "boolean",
+      "default": true
+    },
     "nuclideFixHeader": {
       "title": "Nuclide: Fix Header",
       "description": "This is used to fix the header when developing on Nuclide source code. This should rarely affect anything outside of Nuclide source.",
       "type": "boolean",
       "default": true
-    },
-    "reprint": {
-      "title": "Reprint: Format all code",
-      "type": "boolean",
-      "default": false
     },
     "requiresTransferComments": {
       "title": "Requires: Transfer Comments",

--- a/src/atom/formatCode.js
+++ b/src/atom/formatCode.js
@@ -59,13 +59,17 @@ function transformCodeOrShowError(inputSource: string, options: SourceOptions): 
     return inputSource;
   }
   dismissExistingErrorNotification();
-  if (outputSource === inputSource) {
+  if (
+    outputSource === inputSource &&
+    // Do not confirm success if user opted out
+    atom.config.get('nuclide-format-js.confirmNoChangeSuccess')
+  ) {
     showSuccessNotification();
   }
   return outputSource;
 }
 
-const ERROR_TITLE = 'nuclide-format-js failed';
+const ERROR_TITLE = 'Nuclide Format JS: Fix Requires failed';
 
 function showErrorNotification(error: Error): void {
   dismissExistingErrorNotification();
@@ -81,7 +85,7 @@ function dismissExistingErrorNotification(): void {
   dismissNotification(ERROR_TITLE);
 }
 
-const SUCCESS_TITLE = 'nuclide-format-js succeeded';
+const SUCCESS_TITLE = 'Nuclide Format JS: Fix Requires succeeded';
 
 let dismissSuccessNotificationTimeout;
 function showSuccessNotification(): void {

--- a/src/atom/formatCode.js
+++ b/src/atom/formatCode.js
@@ -27,9 +27,7 @@ async function formatCode(options: SourceOptions, editor_: ?TextEditor): Promise
   const inputSource = buffer.getText();
 
   // Auto-require transform.
-  // TODO: Add a limit so the transform is not run on files over a certain size.
-  const {transform} = require('../common');
-  const outputSource = transform(inputSource, options);
+  const outputSource = transformCodeOrShowError(inputSource, options);
 
   // Update the source and position after all transforms are done. Do nothing
   // if the source did not change at all.
@@ -47,6 +45,65 @@ async function formatCode(options: SourceOptions, editor_: ?TextEditor): Promise
   if (atom.config.get('nuclide-format-js.saveAfterRun')) {
     editor.save();
   }
+}
+
+
+function transformCodeOrShowError(inputSource: string, options: SourceOptions): string {
+  const {transform} = require('../common');
+  // TODO: Add a limit so the transform is not run on files over a certain size.
+  let outputSource;
+  try {
+    outputSource = transform(inputSource, options);
+  } catch (error) {
+    showErrorNotification(error);
+    return inputSource;
+  }
+  dismissExistingErrorNotification();
+  if (outputSource === inputSource) {
+    showSuccessNotification();
+  }
+  return outputSource;
+}
+
+const ERROR_TITLE = 'nuclide-format-js failed';
+
+function showErrorNotification(error: Error): void {
+  dismissExistingErrorNotification();
+  dismissExistingSuccessNotification();
+  atom.notifications.addError(ERROR_TITLE, {
+    detail: error.toString(),
+    stack: error.stack,
+    dismissable: true,
+  });
+}
+
+function dismissExistingErrorNotification(): void {
+  dismissNotification(ERROR_TITLE);
+}
+
+const SUCCESS_TITLE = 'nuclide-format-js succeeded';
+
+let dismissSuccessNotificationTimeout;
+function showSuccessNotification(): void {
+  dismissExistingSuccessNotification();
+  atom.notifications.addSuccess(SUCCESS_TITLE, {
+    detail: 'No changes were needed.',
+    dismissable: true,
+  });
+  dismissSuccessNotificationTimeout = setTimeout(() => {
+    dismissExistingSuccessNotification();
+  }, 2000);
+}
+
+function dismissExistingSuccessNotification(): void {
+  dismissNotification(SUCCESS_TITLE);
+  clearTimeout(dismissSuccessNotificationTimeout);
+}
+
+function dismissNotification(title: string): void {
+  atom.notifications.getNotifications()
+    .filter(notification => notification.getMessage() === title)
+    .forEach(notification => notification.dismiss());
 }
 
 module.exports = formatCode;


### PR DESCRIPTION
This is the last major thing I wanted to do here as outlined in https://github.com/facebooknuclide/nuclide-format-js/pull/17. If the file includes a syntax error, instead of silently failing, we show a notification. If the transform produces no changes, we show a short-lived success notification.

Most of the code here makes sure we only show one notification at a time.

I could very easily write a pretty printer for the error message, but I'd rather have it inline (I think we do it now for prettier).

<img width="531" alt="screen shot 2017-06-19 at 01 31 45" src="https://user-images.githubusercontent.com/1473433/27265743-b920c4f6-5491-11e7-8212-ee1b665be749.png">
<img width="493" alt="screen shot 2017-06-19 at 01 31 37" src="https://user-images.githubusercontent.com/1473433/27265746-bccfbbde-5491-11e7-9ebf-6b6aef626f75.png">
