### PR TITLE
Add option to disable JSX suffix

### DIFF
--- a/__tests__/requiresTransform-spec.js
+++ b/__tests__/requiresTransform-spec.js
@@ -75,6 +75,7 @@ const TESTS = [
 
 const SOURCE_OPTIONS = {
   moduleMap: DefaultModuleMap,
+  jsxSuffix: true,
 };
 
 function readFileP(filename: string): Promise<string> {

--- a/package.json
+++ b/package.json
@@ -119,6 +119,12 @@
       "type": "boolean",
       "default": true
     },
+    "jsxSuffix": {
+      "title": "React: Add module name suffix",
+      "description": "Attach the `.react` suffix to React component module names.",
+      "type": "boolean",
+      "default": true
+    },
     "requiresTransferComments": {
       "title": "Requires: Transfer Comments",
       "type": "boolean",

--- a/src/atom/index.js
+++ b/src/atom/index.js
@@ -22,7 +22,7 @@ export function activate(state: ?Object): void {
     return;
   }
 
-  require("regenerator-runtime/runtime");
+  require('regenerator-runtime/runtime');
   const formatCode = require('./formatCode');
   const {calculateOptions, observeSettings} = require('./settings');
 

--- a/src/atom/settings.js
+++ b/src/atom/settings.js
@@ -22,6 +22,7 @@ export type Settings = {
   aliases: Array<[string, string]>,
   builtIns: Array<string>,
   builtInTypes: Array<string>,
+  jsxSuffix: boolean,
   nuclideFixHeader: boolean,
   requiresTransferComments: boolean,
   requiresRemoveUnusedRequires: boolean,
@@ -58,6 +59,7 @@ export function calculateOptions(settings: Settings): SourceOptions {
   return {
     blacklist: calculateBlacklist(settings),
     moduleMap: calculateModuleMap(settings),
+    jsxSuffix: settings.jsxSuffix,
   };
 }
 

--- a/src/common/options/RequireOptions.js
+++ b/src/common/options/RequireOptions.js
@@ -16,5 +16,5 @@ import type {AbsolutePath} from '../types/common';
 export type RequireOptions = {
   sourcePath?: AbsolutePath,
   typeImport?: boolean,
-  jsxIdentifier?: boolean,
+  jsxSuffix?: boolean,
 };

--- a/src/common/options/SourceOptions.js
+++ b/src/common/options/SourceOptions.js
@@ -13,10 +13,11 @@ import type ModuleMap from '../state/ModuleMap';
 import type {TransformKey} from '../types/transforms';
 
 export type SourceOptions = {
-  moduleMap: ModuleMap,
-  sourcePath?: AbsolutePath,
   /**
    * The set of transforms to blacklist.
    */
   blacklist?: Set<TransformKey>,
+  moduleMap: ModuleMap,
+  sourcePath?: AbsolutePath,
+  jsxSuffix?: boolean,
 };

--- a/src/common/requires/addMissingRequires.js
+++ b/src/common/requires/addMissingRequires.js
@@ -33,8 +33,8 @@ function addMissingRequires(root: Collection, options: SourceOptions): void {
   // Add missing JSX requires.
   getUndeclaredJSXIdentifiers(root, options).forEach(name => {
     const node = moduleMap.getRequire(name, {
+      jsxSuffix: options.jsxSuffix,
       sourcePath: options.sourcePath,
-      jsxIdentifier: true,
     });
     _first.insertBefore(node);
   });

--- a/src/common/state/ModuleMap.js
+++ b/src/common/state/ModuleMap.js
@@ -156,8 +156,7 @@ class ModuleMap {
         );
         break;
       }
-    } else if (options.jsxIdentifier) {
-      // TODO: Make this configurable so that the suffix for JSX can be changed.
+    } else if (options.jsxSuffix) {
       literal = id + '.react';
     } else {
       // TODO: Make this configurable so that it's possible to only add known


### PR DESCRIPTION
I initially had an implementation for specifying the suffix. But Atom's string type option input doesn't allow empty value if there is a non-empty default. And I'm not aware of the use case for a different suffix anyway. This should work well enough for RN folks. I was thinking about somehow guessing what the behavior should be (file name cannot be relied on, other requires might), but this should do for now.