### PR TITLE
Allow sorting requires in files without any other code

### DIFF
--- a/__tests__/fixtures/requires/allow-only-requires.expected
+++ b/__tests__/fixtures/requires/allow-only-requires.expected
@@ -1,0 +1,2 @@
+require('a');
+require('b');

--- a/__tests__/fixtures/requires/allow-only-requires.test
+++ b/__tests__/fixtures/requires/allow-only-requires.test
@@ -1,0 +1,2 @@
+require('b');
+require('a');

--- a/__tests__/requiresTransform-spec.js
+++ b/__tests__/requiresTransform-spec.js
@@ -42,6 +42,7 @@ const TESTS = [
   'add-template-identifiers',
   'add-try-catches',
   'add-types',
+  'allow-only-requires',
   'demote-requires',
   'ignore-arbitrary-new-lines',
   'ignore-array-pattern-elements',

--- a/src/common/requires/formatRequires.js
+++ b/src/common/requires/formatRequires.js
@@ -113,11 +113,18 @@ function formatRequires(root: Collection): void {
     return nodes.map(reprintRequire).sort(config.comparator);
   });
 
+  const programBody = root.get('program').get('body');
+  const allNodesRemoved = programBody.value.length === 0;
+
   // Build all the nodes we want to insert, then add them
   const allGroups = [[NewLine.statement]];
   nodeGroups.forEach(group => allGroups.push(group, [NewLine.statement]));
-  const nodesToInsert = Array.prototype.concat.apply([], allGroups);
-  nodesToInsert.reverse().forEach(node => _first.insertBefore(node));
+  const nodesToInsert = [].concat(...allGroups);
+  if (allNodesRemoved) {
+    programBody.push(...nodesToInsert);
+  } else {
+    _first.insertBefore(...nodesToInsert);
+  }
 }
 
 /**

--- a/src/common/utils/printRoot.js
+++ b/src/common/utils/printRoot.js
@@ -51,6 +51,9 @@ function printRoot(root: Collection): string {
     output += '\n';
   }
 
+  // Remove spurious newline at the end.
+  output = output.replace(/\n\n$/, '\n');
+
   return output;
 }
 


### PR DESCRIPTION
This was broken, if all you wanted to do was sort (and blacklisted `removeUnusedRequires` etc.)
