### PR TITLE
Remove unused requires from destructuring

### DIFF
--- a/__tests__/fixtures/requires/remove-unused-destructured-requires.expected
+++ b/__tests__/fixtures/requires/remove-unused-destructured-requires.expected
@@ -1,0 +1,5 @@
+const {Z} = require('A');
+
+const {m} = require('B');
+
+const y = Z + m;

--- a/__tests__/fixtures/requires/remove-unused-destructured-requires.test
+++ b/__tests__/fixtures/requires/remove-unused-destructured-requires.test
@@ -1,0 +1,4 @@
+const {Y, Z} = require('A');
+const {m, n} = require('B');
+
+const y = Z + m;

--- a/__tests__/requiresTransform-spec.js
+++ b/__tests__/requiresTransform-spec.js
@@ -65,6 +65,7 @@ const TESTS = [
   'remove-shadowed-requires',
   'remove-shadowed-types',
   'remove-unused-array-patterns',
+  'remove-unused-destructured-requires',
   'remove-unused-destructured-types',
   'remove-unused-requires',
   'remove-unused-types',

--- a/src/common/requires/removeUnusedRequires.js
+++ b/src/common/requires/removeUnusedRequires.js
@@ -8,11 +8,10 @@
  * @flow
  */
 
-import type {Collection} from '../types/ast';
+import type {Collection, NodePath} from '../types/ast';
 import type {SourceOptions} from '../options/SourceOptions';
 
 import getDeclaredIdentifiers from '../utils/getDeclaredIdentifiers';
-import getNamesFromID from '../utils/getNamesFromID';
 import getNonDeclarationIdentifiers from '../utils/getNonDeclarationIdentifiers';
 import hasOneRequireDeclaration from '../utils/hasOneRequireDeclaration';
 import isGlobal from '../utils/isGlobal';
@@ -29,22 +28,67 @@ function removeUnusedRequires(
     [path => !hasOneRequireDeclaration(path.node)],
   );
 
-  // Remove unused requires.
-  root
-    .find(jscs.VariableDeclaration)
-    .filter(path => isGlobal(path))
-    .filter(path => hasOneRequireDeclaration(path.node))
-    .filter(path => {
-      const id = path.node.declarations[0].id;
-      const names = getNamesFromID(id);
-      for (const name of names) {
-        if (used.has(name) && !nonRequires.has(name)) {
-          return false;
-        }
+  jscs.types.visit(root.nodes()[0], {
+    visitVariableDeclaration(path) {
+      if (isGlobal(path) && hasOneRequireDeclaration(path.node)) {
+        pruneNames(path, used, nonRequires);
       }
-      return true;
-    })
-    .remove();
+      // don't traverse this path, there cannot be a toplevel
+      // declaration inside of it
+      return false;
+    },
+  });
+}
+
+// Similar to `getNamesFromID`
+function pruneNames(path: NodePath, used: Set<string>, nonRequires: Set<string>): Set<string> {
+  const node = path.node;
+  const ids = new Set();
+  if (jscs.Identifier.check(node)) {
+    ids.add(node.name);
+  } else if (
+    jscs.RestElement.check(node) ||
+    jscs.SpreadElement.check(node) ||
+    jscs.SpreadProperty.check(node) ||
+    jscs.RestProperty.check(node)
+  ) {
+    for (const id of pruneNames(path.get('argument'), used, nonRequires)) {
+      ids.add(id);
+    }
+  } else if (jscs.Property.check(node) || jscs.ObjectProperty.check(node)) {
+    for (const id of pruneNames(path.get('value'), used, nonRequires)) {
+      ids.add(id);
+    }
+  } else if (jscs.ObjectPattern.check(node)) {
+    const properties = path.get('properties');
+    for (let i = node.properties.length - 1; i >= 0; i--) {
+      const propPath = properties.get(i);
+      for (const id of pruneNames(propPath, used, nonRequires)) {
+        ids.add(id);
+      }
+    }
+  } else if (jscs.ArrayPattern.check(node)) {
+    const elements = path.get('elements');
+    for (let i = node.elements.length - 1; i >= 0; i--) {
+      for (const id of pruneNames(elements.get(i), used, nonRequires)) {
+        ids.add(id);
+      }
+    }
+  } else if (jscs.VariableDeclaration.check(node)) {
+    const idPath = path.get('declarations').get(0).get('id');
+    for (const id of pruneNames(idPath, used, nonRequires)) {
+      ids.add(id);
+    }
+  }
+
+  for (const name of ids) {
+    if (used.has(name) && !nonRequires.has(name)) {
+      return ids;
+    }
+  }
+  path.prune();
+
+  return ids;
 }
 
 module.exports = removeUnusedRequires;


### PR DESCRIPTION
Fixes the second part of #28.

Not happy with having to duplicate the whole logic, but don't have a better idea atm. I tried reusing it, but I would have to convert all the other call sites to use paths instead of nodes, and that's not easy.