### PR TITLE
Do not remove existing JSX requires

### DIFF
--- a/__tests__/fixtures/requires/keep-custom-react-suffix.expected
+++ b/__tests__/fixtures/requires/keep-custom-react-suffix.expected
@@ -1,0 +1,4 @@
+const React = require('React');
+const Y = require('Y.mamlas');
+
+const x = <Y />;

--- a/__tests__/fixtures/requires/keep-custom-react-suffix.test
+++ b/__tests__/fixtures/requires/keep-custom-react-suffix.test
@@ -1,0 +1,3 @@
+const Y = require('Y.mamlas');
+
+const x = <Y />;

--- a/__tests__/requiresTransform-spec.js
+++ b/__tests__/requiresTransform-spec.js
@@ -57,6 +57,7 @@ const TESTS = [
   'ignore-react-when-using-jsx',
   'ignore-requires-in-blocks',
   'ignore-rest-args',
+  'keep-custom-react-suffix',
   'keep-header-comments',
   'keep-preceding-block-comments',
   'keep-preceding-single-line-comments',

--- a/src/common/requires/addMissingRequires.js
+++ b/src/common/requires/addMissingRequires.js
@@ -23,18 +23,13 @@ function addMissingRequires(root: Collection, options: SourceOptions): void {
   const _first = first; // For flow.
 
   const {moduleMap} = options;
+  const jsxIdentifiers = getUndeclaredJSXIdentifiers(root, options);
 
   // Add the missing requires.
   getUndeclaredIdentifiers(root, options).forEach(name => {
-    const node = moduleMap.getRequire(name, {sourcePath: options.sourcePath});
-    _first.insertBefore(node);
-  });
-
-  // Add missing JSX requires.
-  getUndeclaredJSXIdentifiers(root, options).forEach(name => {
     const node = moduleMap.getRequire(name, {
-      jsxSuffix: options.jsxSuffix,
-      sourcePath: options.sourcePath,
+      jsxSuffix: jsxIdentifiers.has(name) ? options.jsxSuffix : undefined,
+      sourcePath: options.sourcePath
     });
     _first.insertBefore(node);
   });

--- a/src/common/requires/removeUnusedTypes.js
+++ b/src/common/requires/removeUnusedTypes.js
@@ -43,7 +43,7 @@ const CONFIG: Array<ConfigEntry> = [
 
 function removeUnusedTypes(root: Collection, options: SourceOptions): void {
   const declared = getDeclaredIdentifiers(root, options);
-  const used = getNonDeclarationTypes(root, options);
+  const used = getNonDeclarationTypes(root);
   const nonTypeImport = getDeclaredTypes(
     root,
     options,

--- a/src/common/utils/getJSXIdentifierName.js
+++ b/src/common/utils/getJSXIdentifierName.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Collection, Node, NodePath} from '../types/ast';
+
+import jscs from 'jscodeshift';
+import {isLowerCase} from './StringUtils';
+
+// TODO: make this configurable somehow, we probably don't want to explicitly
+// list out all of the lowercase html tags that are built-in
+const LOWER_CASE_WHITE_LIST = new Set(['fbt']);
+
+/**
+ * Returns an array of nodes for convenience.
+ */
+function getJSXIdentifierName(path: NodePath): Array<Node> {
+  if (jscs.JSXIdentifier.check(path.node.name)) {
+    const name = path.node.name.name;
+    // TODO: should this be here or in addMissingRequires?
+    if (!isLowerCase(name) || LOWER_CASE_WHITE_LIST.has(name)) {
+      return [path.node.name];
+    }
+  }
+  return [];
+}
+
+module.exports = getJSXIdentifierName;

--- a/src/common/utils/getJSXIdentifiers.js
+++ b/src/common/utils/getJSXIdentifiers.js
@@ -10,12 +10,8 @@
 
 import type {Collection} from '../types/ast';
 
+import getJSXIdentifierName from './getJSXIdentifierName';
 import jscs from 'jscodeshift';
-import {isLowerCase} from './StringUtils';
-
-// TODO: make this configurable somehow, we probably don't want to explicitly
-// list out all of the lowercase html tags that are built-in
-const LOWER_CASE_WHITE_LIST = new Set(['fbt']);
 
 /**
  * This will get a list of identifiers for JSXElements in the AST
@@ -26,13 +22,10 @@ function getJSXIdentifiers(root: Collection): Set<string> {
     // There should be an opening element for every single closing element so
     // we can just look for opening ones
     .find(jscs.JSXOpeningElement)
-    .filter(path => jscs.JSXIdentifier.check(path.node.name))
     .forEach(path => {
-      const name = path.node.name.name;
-      // TODO: should this be here or in addMissingRequires?
-      if (!isLowerCase(name) || LOWER_CASE_WHITE_LIST.has(name)) {
-        ids.add(name);
-      }
+      getJSXIdentifierName(path).forEach(node => {
+        ids.add(node.name);
+      });
     });
   return ids;
 }

--- a/src/common/utils/getNamesFromID.js
+++ b/src/common/utils/getNamesFromID.js
@@ -14,7 +14,7 @@ import jscs from 'jscodeshift';
 
 function getNamesFromID(node: Node): Set<string> {
   const ids = new Set();
-  if (jscs.Identifier.check(node)) {
+  if (jscs.Identifier.check(node) || jscs.JSXIdentifier.check(node)) {
     ids.add(node.name);
   } else if (
     jscs.RestElement.check(node) ||

--- a/src/common/utils/getNonDeclarationIdentifiers.js
+++ b/src/common/utils/getNonDeclarationIdentifiers.js
@@ -11,6 +11,7 @@
 import type {Collection, Node, NodePath} from '../types/ast';
 import type {SourceOptions} from '../options/SourceOptions';
 
+import getJSXIdentifierName from './getJSXIdentifierName';
 import getNamesFromID from './getNamesFromID';
 import jscs from 'jscodeshift';
 
@@ -178,7 +179,12 @@ const CONFIG: Array<ConfigEntry> = [
   // Special case. Any JSX elements will get transpiled to use React.
   {
     nodeType: jscs.JSXOpeningElement,
-    getNodes: (path, options) => (shouldRequireReact(path, options) ? [REACT_NODE] : []),
+    getNodes: (path, options) =>
+      getJSXIdentifierName(path).concat(
+        shouldRequireReact(path, options)
+          ? [REACT_NODE]
+          : [],
+      ),
   },
 
   // foo`something`


### PR DESCRIPTION
Previously React requires were always wiped out. This meant that comment preservation didn't work for them, whether they had custom extension or not. So the fix is actually more fundamental than the test suggests. This does change the behavior, so if you forget `.react` suffix the script will no longer work, which is a shame, but it makes the life easier for everyone who doesn't use `.react`.