### PR TITLE
Change grouping of capitalized specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ transforms:
 
 + Don't shadow require names anywhere in the file. The transform is very minimally aware of scope.
 + Don't alias requires (unless you specify the alias in the aliases setting).
-+ Destructure in a line separate from the require:
++ Destructure in a line separate from the require (this is a general best practice):
 
 ```js
 var React = require('react');
@@ -37,8 +37,8 @@ There are 4 groups separated by a blank line:
 
 1. type `import`s
 2. bare `require`s
-3. `require`s assigned to capitalized names (including in destructuring)
-4. `require`s assigned to uncapitalized names (including at least one in destructuring)
+3. `require`s assigned to capitalized names
+4. `require`s assigned to uncapitalized names or object/array destructuring
 
 For example:
 
@@ -55,8 +55,8 @@ const d = require('d');
 Each group is then ordered by the module name (the string on the right hand side), ignoring
 its letter casing. The reason for using the module name as opposed to the type or value names
 on the left hand side is that with changing names in destructuring it is more likely that lines
-would shift, causing merge conflicts. Destructuring lists are also sorted by imported names,
-with uncapitalized names grouped first.
+would shift, causing merge conflicts. Type and object destructuring lists are also sorted by
+imported names, with uncapitalized names grouped first.
 
 ### Scope
 

--- a/__tests__/fixtures/requires/group-capital-specifiers-with-lowercase.expected
+++ b/__tests__/fixtures/requires/group-capital-specifiers-with-lowercase.expected
@@ -1,0 +1,6 @@
+const D = require('D');
+
+const {P, Q} = require('X');
+const {aA, aB, B, C} = require('Z');
+
+aA(aB(B, C, D, Q, P))

--- a/__tests__/fixtures/requires/group-capital-specifiers-with-lowercase.test
+++ b/__tests__/fixtures/requires/group-capital-specifiers-with-lowercase.test
@@ -1,0 +1,6 @@
+
+
+const {C, B, aB, aA} = require('Z');
+const {Q, P} = require('X');
+
+aA(aB(B, C, D, Q, P))

--- a/__tests__/requiresTransform-spec.js
+++ b/__tests__/requiresTransform-spec.js
@@ -46,6 +46,7 @@ const TESTS = [
   'add-types',
   'allow-only-requires',
   'demote-requires',
+  'group-capital-specifiers-with-lowercase',
   'ignore-arbitrary-new-lines',
   'ignore-array-pattern-elements',
   'ignore-builtin-types',

--- a/src/common/requires/formatRequires.js
+++ b/src/common/requires/formatRequires.js
@@ -57,7 +57,7 @@ const CONFIG: Array<ConfigEntry> = [
     filters: [
       isGlobal,
       path => isValidRequireDeclaration(path.node),
-      path => isCapitalized(getDeclarationName(path.node)),
+      path => isCapitalizedModuleDeclaration(path.node),
     ],
     comparator: (node1, node2) => compareStrings(
       getDeclarationModuleName(node1),
@@ -66,12 +66,13 @@ const CONFIG: Array<ConfigEntry> = [
   },
 
   // Handle lowerCase requires, e.g: `const lowerCase = require('lowerCase');`
+  // and destructuring
   {
     nodeType: jscs.VariableDeclaration,
     filters: [
       isGlobal,
       path => isValidRequireDeclaration(path.node),
-      path => !isCapitalized(getDeclarationName(path.node)),
+      path => !isCapitalizedModuleDeclaration(path.node),
     ],
     comparator: (node1, node2) => compareStrings(
       getDeclarationModuleName(node1),
@@ -151,26 +152,12 @@ function isValidRequireDeclaration(node: Node): boolean {
   return false;
 }
 
-function getDeclarationName(node: Node): string {
+function isCapitalizedModuleDeclaration(node: Node): boolean {
   const declaration = node.declarations[0];
   if (jscs.Identifier.check(declaration.id)) {
-    return declaration.id.name;
+    return isCapitalized(declaration.id.name);
   }
-  // Identify by the first uncapitalized or other property name in the object pattern.
-  if (jscs.ObjectPattern.check(declaration.id)) {
-    const uncapitalized = declaration.id.properties
-      .map(property => property.key.name)
-      .filter(name => !isCapitalized(name))[0];
-    return uncapitalized || declaration.id.properties[0].key.name;
-  }
-  // Identify by the first uncapitalized or other element name in the array pattern.
-  if (jscs.ArrayPattern.check(declaration.id)) {
-    const uncapitalized = declaration.id.elements
-      .map(element => element.name)
-      .filter(name => !isCapitalized(name))[0];
-    return uncapitalized || declaration.id.elements[0].name;
-  }
-  return '';
+  return false;
 }
 
 function getDeclarationModuleName(node: Node): string {


### PR DESCRIPTION
These are usually constants, like:

```es6
const URI = require('URI');
const {generateQueryParams} = require('RBWBrowserURLHelper');
const {RBW_TICKER} = require('RBWUIGating');
const {Component, PropTypes} = React;
```
it makes more sense to group them under the modules

```es6
const URI = require('URI');

const cx = require('cx');
const {generateQueryParams} = require('RBWBrowserURLHelper');
const {RBW_TICKER} = require('RBWUIGating');

const {Component, PropTypes} = React;
```