### PR TITLE
Merge duplicate requires and imports

### DIFF
--- a/__tests__/fixtures/requires/remove-duplicate-requires.expected
+++ b/__tests__/fixtures/requires/remove-duplicate-requires.expected
@@ -1,0 +1,13 @@
+import type N from 'N';
+import type {A, B} from 'Z';
+
+import typeof O from 'O';
+
+require('P');
+
+const M = require('M');
+
+const [j, k] = require('Y');
+const {a, b} = require('Z');
+
+const x: A<B, N, O> = a(b, M, j, k);

--- a/__tests__/fixtures/requires/remove-duplicate-requires.test
+++ b/__tests__/fixtures/requires/remove-duplicate-requires.test
@@ -1,0 +1,23 @@
+
+const {a} = require('Z');
+const {b} = require('Z');
+
+import type {A} from 'Z';
+import type {B} from 'Z';
+
+require('P');
+require('P');
+
+const M = require('M');
+const M = require('M');
+
+import type N from 'N';
+import type N from 'N';
+
+import typeof O from 'O';
+import typeof O from 'O';
+
+const [j] = require('Y');
+const [j, k] = require('Y');
+
+const x: A<B, N, O> = a(b, M, j, k);

--- a/__tests__/fixtures/requires/sort-strange-require-expressions.expected
+++ b/__tests__/fixtures/requires/sort-strange-require-expressions.expected
@@ -1,4 +1,5 @@
 require('b')().x;
+require('b')().y;
 
 const D = require('meh').a.b.c('123');
 const E = require('TableWidthsConfig').getWidthConfig().CAMP_GROUP_PANE;

--- a/__tests__/fixtures/requires/sort-strange-require-expressions.test
+++ b/__tests__/fixtures/requires/sort-strange-require-expressions.test
@@ -1,4 +1,5 @@
 const a = require('a')()()().a().b.c[0];
+require('b')().y;
 require('b')().x;
 const D = require('meh').a.b.c('123');
 const C = 'not'.a.require('meh');

--- a/__tests__/requiresTransform-spec.js
+++ b/__tests__/requiresTransform-spec.js
@@ -65,6 +65,7 @@ const TESTS = [
   'keep-preceding-single-line-comments',
   'keep-trailing-comments',
   'promote-types',
+  'remove-duplicate-requires',
   'remove-extra-new-lines',
   'remove-nested-object-pattern',
   'remove-react-when-using-fbt',


### PR DESCRIPTION
Fixes #44 

Before this diff the test would return:
```es6
import type N from 'N';
import type N from 'N';
import type {A} from 'Z';
import type {B} from 'Z';

import typeof O from 'O';
import typeof O from 'O';

require('P');
require('P');

const M = require('M');
const M = require('M');

const [j] = require('Y');
const [j, k] = require('Y');
const {a} = require('Z');
const {b} = require('Z');

const x: A<B, N, O> = a(b, M, j, k);
```
Also fixes sorting of strange bare require calls.

It doesn't support

```es6
const [x] = require('A');
const {y} = require('A');
```
but I hope that no one in their right mind is doing that (fixable if people do though).