### PR TITLE
Fixes a couple sorting bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ const e = require('e');
 Each group is then ordered by the module name (the string on the right hand side), with capitalized names being first. The reason for using the module name as opposed to the type or value names
 on the left hand side is that with changing names in destructuring it is more likely that lines
 would shift, causing merge conflicts. Type and object destructuring lists are also sorted by
-local names, with uncapitalized names grouped first.
+local names, with capitalized names grouped first.
 
 ### Scope
 

--- a/__tests__/fixtures/requires/group-capital-specifiers-with-lowercase.expected
+++ b/__tests__/fixtures/requires/group-capital-specifiers-with-lowercase.expected
@@ -1,5 +1,5 @@
 const D = require('D');
 const {P, Q} = require('X');
-const {aA, aB, B, C} = require('Z');
+const {B, C, aA, aB} = require('Z');
 
 aA(aB(B, C, D, Q, P))

--- a/__tests__/fixtures/requires/sort-aliases.expected
+++ b/__tests__/fixtures/requires/sort-aliases.expected
@@ -1,6 +1,7 @@
 const Aoel = require('Aoel');
-const Immutable = require('immutable');
 const Zena = require('Zena');
+
+const Immutable = require('immutable');
 
 Aoel.Map();
 Immutable.List();

--- a/__tests__/fixtures/requires/sort-require-aliasing-specifiers.expected
+++ b/__tests__/fixtures/requires/sort-require-aliasing-specifiers.expected
@@ -1,5 +1,5 @@
 const X = require('X');
-const {a: d, b: C} = require('Y');
+const {b: C, a: d} = require('Y');
 
 const {c} = require('z');
 

--- a/__tests__/fixtures/requires/sort-require-aliasing-specifiers.test
+++ b/__tests__/fixtures/requires/sort-require-aliasing-specifiers.test
@@ -1,6 +1,6 @@
 
 
-const {b: C, a: d} = require('Y');
+const {a: d, b: C} = require('Y');
 const {c} = require('z');
 
 c(d(C, X));

--- a/__tests__/fixtures/requires/sort-require-specifiers.expected
+++ b/__tests__/fixtures/requires/sort-require-specifiers.expected
@@ -1,6 +1,6 @@
 const D = require('D');
-const {s, P, Q} = require('X');
-const {aA, aB, B, C} = require('Z');
+const {P, Q, s} = require('X');
+const {B, C, aA, aB} = require('Z');
 
 aA(aB(B, C, D))
 s(Q, P)

--- a/__tests__/fixtures/requires/sort-require-specifiers.test
+++ b/__tests__/fixtures/requires/sort-require-specifiers.test
@@ -1,6 +1,6 @@
 
 
-const {C, B, aB, aA} = require('Z');
+const {aB, aA, C, B} = require('Z');
 const {s, Q, P} = require('X');
 
 aA(aB(B, C, D))

--- a/src/common/requires/formatRequires.js
+++ b/src/common/requires/formatRequires.js
@@ -182,8 +182,7 @@ function isValidRequireDeclaration(node: Node): boolean {
 }
 
 function isCapitalizedRequireName(node: Node, options: SourceOptions): boolean {
-  const rawName = getModuleName(node.declarations[0].init);
-  return isCapitalized(normalizeModuleName(rawName, options));
+  return isCapitalized(getModuleName(node.declarations[0].init));
 }
 
 function isCapitalizedImportName(node: Node, options: SourceOptions): boolean {

--- a/src/common/utils/reprintRequire.js
+++ b/src/common/utils/reprintRequire.js
@@ -10,7 +10,7 @@
 
 import type {Node} from '../types/ast';
 
-import {compareStringsCapitalsLast} from './StringUtils';
+import {compareStringsCapitalsLast, compareStringsCapitalsFirst} from './StringUtils';
 import jscs from './jscodeshift';
 import oneLineObjectPattern from './oneLineObjectPattern';
 import reprintComment from './reprintComment';
@@ -60,7 +60,7 @@ function reprintRequireHelper(nodes: Array<Node>): Node {
       });
       removeDuplicatesInPlace(declaration.id.properties, one => one.value.name);
       declaration.id.properties.sort((prop1, prop2) => {
-        return compareStringsCapitalsLast(prop1.value.name, prop2.value.name);
+        return compareStringsCapitalsFirst(prop1.value.name, prop2.value.name);
       });
       return jscs.variableDeclaration(
         kind,


### PR DESCRIPTION
Destructured require fields should have capitalized entries first.
Requires should be sorted based on their raw module names, not aliases.